### PR TITLE
Updates to Homepage

### DIFF
--- a/web/src/components/HorizontalCard/HorizontalCard.js
+++ b/web/src/components/HorizontalCard/HorizontalCard.js
@@ -7,7 +7,7 @@ const HorizontalCard = (props) => {
 
   const { data, error } = props;
   
-  const time = Moment(props.date).format('h:mm a')
+  const time = Moment(props.date).format('MMMM DD, YYYY')
 
   return (
     <Card className={props.className}>

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -92,7 +92,7 @@ const IndexPage = props => {
 
   const events = (data.allSanityEvents.nodes || {})
 
-  const feature_event = (data.sanityEvents || {})
+  let feature_event = (data.sanityEvents ? data.sanityEvents : events[0]) //if there is no featured event, then set the closest event to be featured
 
   let eventsNoFeature = []; {/* Create empty array for events to filter into */}
 
@@ -101,8 +101,8 @@ const IndexPage = props => {
     }
   )
   eventsNoFeature = eventsNoFeature.slice(0, 3); {/* Slice the list to only contain 3 elements max */}
-  
 
+  
   const courses = (data.allSanityCourses.nodes || {})
 
   if (errors) {


### PR DESCRIPTION
Fix for: issue #19 

- If there is no event tagged as `featured`, the featured event card will show the **closest event**
- Updated time on event cards to show `Month Day, Year` (Like the current live site)