### PR TITLE
new build command for netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "lerna run format",
     "build-studio": "(cd studio && npm run build)",
     "export-db": "cd studio && SANITY_AUTH_TOKEN=$SANITY_DEPLOY_STUDIO_TOKEN sanity dataset export production ./production.tar.gz",
+    "import-db": "SANITY_AUTH_TOKEN=$SANITY_DEPLOY_STUDIO_TOKEN sanity dataset import ./production.tar.gz dev --replace",
     "build-web": "lerna bootstrap --no-ci && (cd studio && SANITY_AUTH_TOKEN=$SANITY_DEPLOY_STUDIO_TOKEN npm run graphql-deploy) && (cd web && npm run build)",
     "graphql-deploy": "lerna run graphql-deploy",
     "lint": "lerna run lint",


### PR DESCRIPTION
Added the `import dataset` command after the `export dataset` command

it should export data from the `production` dataset and then import that data into the `dev` dataset
- I just have it backward for testing, in production, we would want it to transfer the data from `dev` -> `production`
 