### PR TITLE
455 blog author image scaling responsiveness

### DIFF
--- a/web/src/templates/blog/BlogPreview.js
+++ b/web/src/templates/blog/BlogPreview.js
@@ -23,8 +23,8 @@ export default function BlogPreview({ blog }) {
   return (
     <Col xs={12} md={6} className="mt-4 px-0 px-sm-2" key={edge.id}>
       <Container className="blog-card border border-2 rounded-1">
-        <Row className="p-3 h-100">
-          <Col xs={12} className="p-0">
+        <Row className="p-3">
+          <Col xs={12} className="p-0 d-flex">
             <Container
               className="blog-image d-flex flex-column"
               style={{

--- a/web/src/templates/blog/BlogPreview.scss
+++ b/web/src/templates/blog/BlogPreview.scss
@@ -5,7 +5,9 @@
   letter-spacing: 0 !important;
 }
 .blog-card {
-  height: 60vh;
+
+  height: 500px;
+  
 
   @include screen-xs {
     height: 85vh;

--- a/web/src/templates/blog/blog-template.js
+++ b/web/src/templates/blog/blog-template.js
@@ -41,24 +41,21 @@ const Blog = ({ pageContext }) => {
           <Col sm={{ span: 8, offset: 2 }}>
             <Title className="mt-5">{blogInfo.title}</Title>
             <Container className="my-4">
-              <Row className="">
-                <Col
-                  xs={{ span: 2 }}
-                  sm={{ span: 1 }}
-                  className="d-flex justify-content-center p-0 rounded-circle border border-1 border-dark"
-                >
+              <Row >
+                <Col xs={{span:3}} sm={{span:4}} md={{span: 2}} >
                   <GatsbyImage
                     objectFit="cover"
                     image={authorImage}
                     // image={'../../images/ainc-logo-horizontal-white-text.png'}
                     alt={blogInfo.reference.name}
-                    className="rounded-circle border border-3 border-white p-1"
+                    className="rounded-circle p-4"
+                    style={{ outline: "1px solid black", border: "3px solid white" }}
                   />
                 </Col>
                 <Col
                   xs={{ span: 10 }}
                   sm={{ span: 10 }}
-                  className="d-flex justify-content-start align-content-center flex-column mt-2 mt-sm-1 mx-0 mx-sm-1"
+                  className="d-flex justify-content-start align-content-center flex-column mt-2 mx-0"
                 >
                   <Title className={`${styles.author} mb-0`}>
                     {blogInfo.reference.name}, {blogInfo.reference.title}


### PR DESCRIPTION
This PR addresses two issues on the blog page: 
- the outline on the profile pic on the blog page was not scaling correctly:
         Fixed this by deleting the outline component and used styling for a border and outline to create the same visual result. 
- the text in the blog preview page was bleeding outside of the border of smaller screens.
         Fixed this by changing the height style from 60vh to 500px 
    