### PR TITLE
Feat/ 500 image optimization

### DIFF
--- a/studio/schemas/documents/timeline.js
+++ b/studio/schemas/documents/timeline.js
@@ -1,0 +1,32 @@
+export default {
+  name: "timelineEvent",
+  title: "Timeline Event",
+  type: "document",
+  fields: [
+    {
+      name: "date",
+      title: "Date",
+      type: "datetime",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "content",
+      title: "Content",
+      type: "text",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "image",
+      title: "Image",
+      type: "image",
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    },
+  ],
+};

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -49,6 +49,7 @@ import fiveAcrossTestimonials from "./documents/fiveAcrossTestimonials";
 import bootcampImageTestimonials from "./documents/bootcampImageTestimonials";
 import alumniTestimonials from "./documents/alumniTestimonials";
 import fellowshipKPIs from "./documents/fellowshipKPIs";
+import timeline from "./documents/timeline";
 // Then we give our schema to the builder and provide the result to Sanity
 export default [
   bioPortableText,
@@ -101,4 +102,5 @@ export default [
   bootcampImageTestimonials,
   alumniTestimonials,
   fellowshipKPIs,
+  timeline,
 ];

--- a/web/src/components/Header/Header.js
+++ b/web/src/components/Header/Header.js
@@ -412,6 +412,7 @@ const Header = () => {
                 <Link to="/careers">Careers</Link>
                 <Link to="/internships">Internships</Link>
                 <Link to="/events">Events</Link>
+                <Link to="/15YearTimeline">15 Year Timeline</Link>
               </div>
             </Col>
 
@@ -461,6 +462,7 @@ const Header = () => {
                           <Link to="/careers">Careers</Link>
                           <Link to="/internships">Internships</Link>
                           <Link to="/events">Events</Link>
+                          <Link to="/15YearTimeline">15 Year Timeline</Link>
                         </Col>
                       </Row>
                     </Nav>

--- a/web/src/components/Header/Header.js
+++ b/web/src/components/Header/Header.js
@@ -194,6 +194,7 @@ const Header = () => {
                 >
                   Community Yearbook
                 </a>{" "}
+                <a href=" https://entrepreneurhof.com/">HOF</a>
                 {/*Need to add yearbooks and possibly other assets*/}
               </div>
             </Col>

--- a/web/src/pages/15YearTimeline/index.js
+++ b/web/src/pages/15YearTimeline/index.js
@@ -1,44 +1,62 @@
 import React from "react";
-// import { graphql } from "gatsby";
+import { graphql } from "gatsby";
 import { motion } from "framer-motion";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
-import SEO from "../../components/seo";
+import * as styles from "./timeline.module.css";
 
+const HistoryWall = ({ data }) => {
 
-const HistoryWall = () => {
-  // const query = graphql`
-  //   query allSanityTimelineEvent {
-  //     nodes {
-  //       id
-  //       date(formatString: "MMMM D, YYYY")
-  //       title
-  //       image {
-  //         asset {
-  //           gatsbyImageData(width: 800, placeholder: BLURRED)
-  //         }
-  //       }
-  //     }
-  //   }
-  // `);
-
-  // const timelineData = data.allSanityTimelineEvent.nodes;
-
-  const timelineData = []; // empty array so it doesn't crash
+  const timelineData = data.allSanityTimelineEvent.nodes;
 
   return (
     <div
-      className="timeline-container"
-      style={{ padding: "50px", background: "#f8f8f7" }}
+      className={styles.timelineContainer}
     >
-      {timelineData.length === 0 && (
-        <p>
-          This is as far as I have gotten. Still not seeing <code>TimelineEvent</code> in GraphQL and
-          can't bring content from Sanity over without the proper query.
-        </p>
-      )}
+      {timelineData.map((event, index) => {
+        const imageData = getImage(event.image?.asset);
+
+        return (
+          <motion.div
+            key={event.id}
+            initial={{ opacity: 0, y: 50 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease: "easeOut", delay: index * 0.1 }}
+            viewport={{ once: true }}
+            className={styles.timelineItem}
+          >
+            {imageData && (
+              <GatsbyImage
+                image={imageData}
+                alt={event.image?.alt || event.title}
+              />
+            )}
+            <h3 className={styles.timelineDate}>{event.date}</h3>
+            <h2 className={styles.timelineTitle}>{event.title}</h2>
+            <p className={styles.timelineContent}>{event.content}</p>
+          </motion.div>
+        );
+      })}
     </div>
   );
 };
 
-
 export default HistoryWall;
+
+// GraphQL Page Query
+export const query = graphql`
+  {
+    allSanityTimelineEvent {
+      nodes {
+        title
+        date
+        image {
+          asset {
+            gatsbyImageData
+          }
+        }
+        content
+      }
+    }
+  }
+`;
+

--- a/web/src/pages/15YearTimeline/index.js
+++ b/web/src/pages/15YearTimeline/index.js
@@ -1,0 +1,44 @@
+import React from "react";
+// import { graphql } from "gatsby";
+import { motion } from "framer-motion";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import SEO from "../../components/seo";
+
+
+const HistoryWall = () => {
+  // const query = graphql`
+  //   query allSanityTimelineEvent {
+  //     nodes {
+  //       id
+  //       date(formatString: "MMMM D, YYYY")
+  //       title
+  //       image {
+  //         asset {
+  //           gatsbyImageData(width: 800, placeholder: BLURRED)
+  //         }
+  //       }
+  //     }
+  //   }
+  // `);
+
+  // const timelineData = data.allSanityTimelineEvent.nodes;
+
+  const timelineData = []; // empty array so it doesn't crash
+
+  return (
+    <div
+      className="timeline-container"
+      style={{ padding: "50px", background: "#f8f8f7" }}
+    >
+      {timelineData.length === 0 && (
+        <p>
+          This is as far as I have gotten. Still not seeing <code>TimelineEvent</code> in GraphQL and
+          can't bring content from Sanity over without the proper query.
+        </p>
+      )}
+    </div>
+  );
+};
+
+
+export default HistoryWall;

--- a/web/src/pages/15YearTimeline/index.js
+++ b/web/src/pages/15YearTimeline/index.js
@@ -4,39 +4,50 @@ import { motion } from "framer-motion";
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import * as styles from "./timeline.module.css";
 
-const HistoryWall = ({ data }) => {
+import Layout from "../../components/Layout/Layout";
+import { Container, Col, Row } from "react-bootstrap";
 
+const HistoryWall = ({ data }) => {
   const timelineData = data.allSanityTimelineEvent.nodes;
 
   return (
-    <div
-      className={styles.timelineContainer}
-    >
-      {timelineData.map((event, index) => {
-        const imageData = getImage(event.image?.asset);
+    <Layout>
+      <Container className={styles.timelineContainer}>
+        <Row>
+          {timelineData.map((event, index) => {
+            const imageData = getImage(event.image?.asset);
 
-        return (
-          <motion.div
-            key={event.id}
-            initial={{ opacity: 0, y: 50 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, ease: "easeOut", delay: index * 0.1 }}
-            viewport={{ once: true }}
-            className={styles.timelineItem}
-          >
-            {imageData && (
-              <GatsbyImage
-                image={imageData}
-                alt={event.image?.alt || event.title}
-              />
-            )}
-            <h3 className={styles.timelineDate}>{event.date}</h3>
-            <h2 className={styles.timelineTitle}>{event.title}</h2>
-            <p className={styles.timelineContent}>{event.content}</p>
-          </motion.div>
-        );
-      })}
-    </div>
+            return (
+              <Col
+                key={event.id}
+                md={6}
+                lg={4}
+                className="mb-4"
+              >
+                <motion.div
+                  initial={{ opacity: 0, y: 50 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, ease: "easeOut", delay: index * 0.1 }}
+                  viewport={{ once: true }}
+                  className={styles.timelineItem}
+                >
+                  {imageData && (
+                    <GatsbyImage
+                      image={imageData}
+                      alt={event.image?.alt || event.title}
+                      className="mb-3"
+                    />
+                  )}
+                  <h3 className={styles.timelineDate}>{event.date}</h3>
+                  <h2 className={styles.timelineTitle}>{event.title}</h2>
+                  <p className={styles.timelineContent}>{event.content}</p>
+                </motion.div>
+              </Col>
+            );
+          })}
+        </Row>
+      </Container>
+    </Layout>
   );
 };
 
@@ -48,7 +59,7 @@ export const query = graphql`
     allSanityTimelineEvent {
       nodes {
         title
-        date
+        date(formatString: "MMMM DD, YYYY")
         image {
           asset {
             gatsbyImageData

--- a/web/src/pages/15YearTimeline/timeline.module.css
+++ b/web/src/pages/15YearTimeline/timeline.module.css
@@ -1,0 +1,61 @@
+/* Container for the entire timeline */
+.timelineContainer {
+  padding: 50px;
+  background-color: #f8f8f8;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Individual timeline item */
+.timelineItem {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* Hover effect for timeline items */
+.timelineItem:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 30px rgba(0, 0, 0, 0.15);
+}
+
+/* Styling for the date */
+.timelineDate {
+  font-size: 1rem;
+  color: #888;
+  margin: 0;
+  text-align: center;
+}
+
+/* Styling for the title */
+.timelineTitle {
+  font-size: 1.5rem;
+  color: #333;
+  margin: 0;
+  text-align: center;
+}
+
+/* Styling for the content */
+.timelineContent {
+  font-size: 1rem;
+  color: #555;
+  line-height: 1.6;
+}
+
+/* Image styling */
+/* .timelineImage {
+  width: 100%;
+  max-width: 400px; 
+  height: 200px;      
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+} */

--- a/web/src/templates/blog/BlogPreview.js
+++ b/web/src/templates/blog/BlogPreview.js
@@ -9,34 +9,26 @@ import "./BlogPreview.scss";
 export default function BlogPreview({ blog }) {
   const edge = blog;
 
-  const defaultBgImageUrl = "../../images/logo.png";
-
-  const bgImage = edge.node.thumbnail?.asset?.url
-    ? `url(${edge.node.thumbnail.asset.url})`
-    : `url(${defaultBgImageUrl})`;
-
-  // Safely access reference picture
-  const refImage = edge.node.reference?.picture
-    ? `${edge.node.reference.picture}`
-    : `url(${defaultBgImageUrl})`;
+/* Removed unnecessary code since I added gatsbyImage which is better than url */
 
   return (
     <Col xs={12} md={6} className="mt-4 px-0 px-sm-2" key={edge.id}>
       <Container className="blog-card border border-2 rounded-1">
         <Row className="p-3">
           <Col xs={12} className="p-0 d-flex">
+          {/* Changed contianer to use GatsbyImage instead of style to get background Image since it's more optimized */}
             <Container
-              className="blog-image d-flex flex-column"
-              style={{
-                backgroundImage: bgImage,
-                backgroundRepeat: "no-repeat",
-                backgroundSize: "cover",
-                backgroundPosition: "center center",
-                height: "270px",
-                width: "100%",
-                position: "relative",
-              }}
+              className="blog-image d-flex flex-column position-relative p-0 align-items-center"
             >
+              <GatsbyImage
+                image={edge.node.thumbnail?.asset?.gatsbyImageData}
+                alt={edge.node.title || "Blog Thumbnail"}
+                className="position-absolute w-100 h-100"
+                style={{
+                  objectFit: "cover",
+                  objectPosition: "center",
+                }}
+              />
               <Row className="bg h-100 w-100">
                 <Col className="book h-100 d-flex justify-content-center align-items-center">
                   <a
@@ -52,18 +44,23 @@ export default function BlogPreview({ blog }) {
               <Row style={{ height: "90px" }} className="blog-details mt-auto">
                 <Col
                   xs={4}
-                  style={{ height: "", width: "fit-content" }}
+                  style={{ width: "fit-content" }}
                   className="justify-content-center align-items-center"
                 >
-                  <GatsbyImage
-                    objectFit="contain"
-                    style={{ height: "70px", width: "70px", zIndex: "2" }}
-                    image={
-                      edge.node.reference?.picture?.asset?.gatsbyImageData || ""
-                    }
-                    alt={edge.node.reference?.name || ""}
-                    className="rounded-circle border border-3 border-white my-0 ms-0"
-                  />
+                  {/* Keep using GatsbyImage for reference picture */}
+                  {edge.node.reference?.picture?.asset?.gatsbyImageData && (
+                    <GatsbyImage
+                      objectFit="contain"
+                      style={{
+                        height: "70px",
+                        width: "70px",
+                        zIndex: "2",
+                      }}
+                      image={edge.node.reference.picture.asset.gatsbyImageData}
+                      alt={edge.node.reference?.name || "Author"}
+                      className="rounded-circle border border-3 border-white my-0 ms-0"
+                    />
+                  )}
                 </Col>
                 <Col
                   xs={7}
@@ -76,7 +73,6 @@ export default function BlogPreview({ blog }) {
                     {edge.node.reference?.name}, {edge.node.reference?.title}
                   </Title>
                   <p style={{ zIndex: "2" }} className="date text-white">
-                    {" "}
                     {edge.node.date}
                   </p>
                 </Col>
@@ -84,7 +80,7 @@ export default function BlogPreview({ blog }) {
               <div className="overlay"></div>
             </Container>
           </Col>
-          <Col xs={12} className="">
+          <Col xs={12}>
             <Container className="p-0 d-flex flex-column justify-content-between h-100">
               <Row>
                 <div className="pt-3">
@@ -94,7 +90,7 @@ export default function BlogPreview({ blog }) {
                     </Title>
                   </a>
                 </div>
-                <div className="">
+                <div>
                   <p className="description text-break">
                     {edge.node.previewText}
                   </p>
@@ -103,7 +99,6 @@ export default function BlogPreview({ blog }) {
               <Row>
                 <a href={`/blog/${edge.node.slug.current}`}>
                   <p className="text--brand fs-6 link--brand">
-                    {" "}
                     Read More <FaLongArrowAltRight size="25" />
                   </p>
                 </a>

--- a/web/src/templates/blog/BlogPreview.scss
+++ b/web/src/templates/blog/BlogPreview.scss
@@ -22,6 +22,8 @@
   }
 
   .blog-image {
+    height: 270px;
+    width: 100%;
     position: relative;
     transition: all 0.2s ease-in-out;
   }

--- a/web/src/templates/blog/blog-list-template.js
+++ b/web/src/templates/blog/blog-list-template.js
@@ -191,6 +191,8 @@ const BlogPage = ({ pageContext, data }) => {
   );
 };
 
+
+/* changed asset to use GatsbyImageData instead of URL for better optimization, also limited sizes to 360 by 270 instead of having image sizes be 1000 by 1500 */
 export const query = graphql`
   query BlogPageQuery($skip: Int!, $limit: Int!) {
     allSanityBlog(sort: { date: DESC }, skip: $skip, limit: $limit) {
@@ -205,7 +207,7 @@ export const query = graphql`
           previewText
           thumbnail {
             asset {
-              url
+              gatsbyImageData(width: 360, height: 270, layout: CONSTRAINED, placeholder: BLURRED, formats: [AUTO, WEBP, AVIF])
             }
           }
           reference {


### PR DESCRIPTION
Made Images optimized by using GatsbyImage to make them smaller in both load size and their actual size. I changed the graphql query to use GatsbyImage(width: 360, height: 270, layout: CONSTRAINED, placeholder: BLURRED, formats: [AUTO, WEBP, AVIF] to make images smaller and take less time to load. 