### PR TITLE
pagination is no longer generated

### DIFF
--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -69,16 +69,11 @@ async function createBlogPostPages(graphql, actions) {
 
   Array.from({ length: numBlogs }).forEach((_, i) => {
     createPage({
-      path: i === 0 ? `/blog` : `/blog/${i + 1}`,
+      path: `/blog`,
       component: require.resolve("./src/templates/blog/blog-list-template.js"),
       // component: require.resolve("./src/pages/blog/index.js"),
 
-      context: {
-        limit: blogsPerPage,
-        skip: i * blogsPerPage,
-        numBlogs,
-        currentBlog: i + 1,
-      },
+      context: {},
     });
   });
 }


### PR DESCRIPTION
Removed /blog/2 through /blog/10 from being generated so /blog/ is the only the only page being generated. Might need to run gatsby clean & develop in production to clear out the cache of the old build