### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Monorepo layout
+
+Yarn 1 workspaces monorepo with two apps:
+
+| Workspace | Purpose | Dev command | URL |
+|-----------|---------|-------------|-----|
+| `web/` | Gatsby 5 frontend (Awesome Inc public site) | `cd web && yarn dev` | http://localhost:8000 |
+| `studio/` | Sanity 3 Content Studio | `cd studio && yarn dev` | http://localhost:3333 |
+
+Install dependencies once from the repo root: `yarn install` (see root `README.md`).
+
+### Environment variables (required for Gatsby)
+
+Gatsby loads `web/.env.development` in development (`gatsby-config.js` uses dotenv). This file is **not committed** (`.gitignore` covers `.env*`). Ask the team lead for the real file, or create one locally with at least:
+
+- `GATSBY_SANITY_DATASET` (typically `production` or `development`)
+- `FIVE_ACROSS_REWARDS_*` Google Sheets service-account fields (required at config load time even if you are not working on 5 Across pages)
+- `SECOND_SPREADSHEET_ID` (needed for `/team-achievements` Netlify API routes)
+- `SANITY_READ_TOKEN` (optional; enables draft overlay in dev)
+
+Sanity Cloud (`projectId: y716vocf`) is hosted; no local database. Studio login is required to edit CMS content.
+
+### Running services
+
+Use **tmux** for long-running dev servers (Gatsby builds can take ~1 minute on first start):
+
+```bash
+# Gatsby
+cd web && yarn dev
+
+# Sanity Studio (optional unless editing schemas/content)
+cd studio && yarn dev
+```
+
+There is no root `yarn dev` script (`.gitpod.yml` is outdated).
+
+### Lint / test
+
+| Workspace | Command | Notes |
+|-----------|---------|-------|
+| `web/` | `yarn lint` | Currently fails without `babel-eslint` in `web` devDependencies (parser referenced in `web/.eslintrc.js`) |
+| `studio/` | `yarn lint` | Runs but reports many pre-existing style violations |
+| `studio/` | `yarn test` | Runs deprecated `sanity check` (no-op) |
+| `web/` | `yarn test` | Placeholder script only |
+
+### Build
+
+- Gatsby production build: `cd web && yarn build`
+- Studio build: `yarn build-studio` from root, or `cd studio && yarn build`
+
+### Netlify serverless functions
+
+`web/src/api/` routes (e.g. team achievements) are served via Netlify functions, not plain `gatsby develop`. Use `netlify dev` from `web/` when testing those endpoints locally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud–specific development instructions discovered during environment setup.

- Documents monorepo layout (`web` Gatsby + `studio` Sanity)
- Notes required `web/.env.development` variables and service URLs
- Captures lint/test caveats and Netlify function dev notes

## Test plan

- [x] `yarn install` from repo root
- [x] `cd web && yarn dev` → http://localhost:8000
- [x] `cd studio && yarn dev` → http://localhost:3333
- [x] Verified homepage, blog, and navigation in browser
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-931da6d6-17b3-46d5-858c-3152c16f7f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-931da6d6-17b3-46d5-858c-3152c16f7f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

