### PR TITLE
Crop and center non-square team photos (about + internships)

### DIFF
--- a/web/src/pages/about/index.js
+++ b/web/src/pages/about/index.js
@@ -209,7 +209,7 @@ export const query_accomplishments = graphql`
         name
         picture {
           asset {
-            gatsbyImageData(width: 200, fit: FILL)
+            gatsbyImageData(width: 200, height: 200, fit: CROP)
           }
         }
       }

--- a/web/src/pages/internships/index.js
+++ b/web/src/pages/internships/index.js
@@ -79,7 +79,12 @@ export const query = graphql`
         role
         picture {
           asset {
-            gatsbyImageData(width: 250, layout: CONSTRAINED, aspectRatio: 1)
+            gatsbyImageData(
+              width: 250
+              height: 250
+              fit: CROP
+              layout: CONSTRAINED
+            )
           }
         }
       }


### PR DESCRIPTION
## Summary
- Team member photos now crop-and-center non-square uploads instead of skewing them.
- /about: team query uses `fit: CROP` at 200x200 (was `fit: FILL`).
- /internships "Meet our Team Alpha Managers": query uses explicit `fit: CROP` at 250x250 (was `aspectRatio: 1` with no fit).
- Respects a Sanity hotspot if one is set; otherwise centers.

## Test plan
- [ ] Upload a non-square team photo in Sanity and confirm it crops/centers (not stretched) on /about and /internships.
