### PR TITLE
Optimize team-achievements boards and fix pin drop scaling

### DIFF
--- a/web/src/api/pinImages.js
+++ b/web/src/api/pinImages.js
@@ -5,7 +5,7 @@ import { google } from "googleapis";
     Images are hosted by post image, src stored in sheet
 */
 export default async function handler(req, res) {
-  const scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+  const scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"];
   const auth = new google.auth.JWT(
     process.env.FIVE_ACROSS_REWARDS_CLIENT_EMAIL,
     null,
@@ -14,27 +14,26 @@ export default async function handler(req, res) {
   );
 
   try {
-     if (req.method === "GET") {
-        await auth.authorize();
-        const sheets = google.sheets({ version: "v4", auth });
+    if (req.method === "GET") {
+      await auth.authorize();
+      const sheets = google.sheets({ version: "v4", auth });
 
-        const pinImages = await sheets.spreadsheets.values.get({
-            spreadsheetId: process.env.SECOND_SPREADSHEET_ID,
-            range: "'Pin Database'!A2:D",
-        });
-        console.log("Images", pinImages)
+      const pinImages = await sheets.spreadsheets.values.get({
+        spreadsheetId: process.env.SECOND_SPREADSHEET_ID,
+        range: "'Pin Database'!A2:D",
+      });
 
-        const imgLinks = (pinImages.data.values || []).map((row) => ({
-            pinName: row[0] || "Unnamed", // A
-            howToEarn: row[1] || "", // B
-            pinCode: row[2] || "", // C
-            source: row[3] || "/images/default-pin.png", // D
-        }))
+      const imgLinks = (pinImages.data.values || []).map((row) => ({
+        pinName: row[0] || "Unnamed", // A
+        howToEarn: row[1] || "", // B
+        pinCode: row[2] || "", // C
+        source: row[3] || "/images/default-pin.png", // D
+      }));
 
-        return res.status(200).json({ imgLinks });
+      return res.status(200).json({ imgLinks });
     }
 
-    // If not GET 
+    // If not GET
     return res.status(405).json({ error: "Method not allowed" });
   } catch (error) {
     console.log("Sheets API Error:", error);

--- a/web/src/api/sheet.js
+++ b/web/src/api/sheet.js
@@ -36,7 +36,6 @@ export default async function handler(req, res) {
         y: parseFloat(row[8]) || null, // I
         uniqueId: row[9] || "", // J
       }));
-      console.log(pins)
 
       return res.status(200).json({ pins });
     }

--- a/web/src/components/CorkBoard/CorkBoard.jsx
+++ b/web/src/components/CorkBoard/CorkBoard.jsx
@@ -30,7 +30,9 @@ const clash = (spots, x, y) =>
       y + PIN_SIZE > s.y,
   );
 
-const CorkBoard = ({
+// Memoized: hover state lives on the page, so without memo every pin hover
+// re-renders every board (and every framer-motion pin) on the page.
+const CorkBoard = React.memo(function CorkBoard({
   initialPins = [],
   onHoverStory,
   teamMembers = [],
@@ -39,7 +41,7 @@ const CorkBoard = ({
   valid,
   group,
   pinScale = DEFAULT_PIN_SCALE,
-}) => {
+}) {
   const [pins, setPins] = useState([]);
   const [groupBounds, setGroupBounds] = useState({});
 
@@ -59,11 +61,8 @@ const CorkBoard = ({
 
   useEffect(() => {
     const groups = initialPins.map((p) => p.group?.trim());
-    setGroupBounds(calculateGroupBounds(groups));
-  }, [initialPins]);
-
-  useEffect(() => {
-    if (!Object.keys(groupBounds).length) return;
+    const bounds = calculateGroupBounds(groups);
+    setGroupBounds(bounds);
 
     const taken = [];
     const placed = [];
@@ -80,7 +79,7 @@ const CorkBoard = ({
         return;
       }
 
-      const lane = groupBounds[p.group?.trim()];
+      const lane = bounds[p.group?.trim()];
       let ok = false;
       let x = lane.xMin;
       let y = lane.yMin;
@@ -128,7 +127,7 @@ const CorkBoard = ({
     });
 
     setPins(placed);
-  }, [initialPins, groupBounds]);
+  }, [initialPins]);
 
   const handleDrop = async (e) => {
     e.preventDefault();
@@ -137,8 +136,10 @@ const CorkBoard = ({
     const { uniqueId, offsetX, offsetY } = JSON.parse(data);
     const rect = e.currentTarget.getBoundingClientRect();
 
-    let x = e.clientX - rect.left - offsetX;
-    let y = e.clientY - rect.top - offsetY;
+    // Drop events report CSS pixels of the scaled board; pin.x/pin.y are stored
+    // in unscaled board coordinates (rendered as `left: pin.x * scale`).
+    let x = (e.clientX - rect.left - offsetX) / scale;
+    let y = (e.clientY - rect.top - offsetY) / scale;
     x = Math.max(EDGE, Math.min(x, BOARD_WIDTH - PIN_SIZE - EDGE));
     y = Math.max(EDGE, Math.min(y, BOARD_HEIGHT - PIN_SIZE - EDGE));
 
@@ -198,6 +199,8 @@ const CorkBoard = ({
         <img
           src={avatar}
           alt={`${boardName} avatar`}
+          loading="lazy"
+          decoding="async"
           style={{
             width: 90 * scale,
             height: 90 * scale,
@@ -261,6 +264,6 @@ const CorkBoard = ({
       </div>
     </div>
   );
-};
+});
 
 export default CorkBoard;

--- a/web/src/components/CorkBoard/Pin.jsx
+++ b/web/src/components/CorkBoard/Pin.jsx
@@ -2,14 +2,37 @@ import React, { useState } from "react";
 import { motion } from "framer-motion";
 import { PIN_SIZE } from "./randomPlacement";
 
-const Pin = ({
+// Row index of each pin type in the "Pin Database" sheet
+const PIN_IMAGE_INDEX = {
+  "Be Good": 0,
+  "Be Excellent": 1,
+  "Be a Friend": 2,
+  "Be You": 3,
+  Billi: 4,
+  Oreo: 5,
+  Balloon: 6,
+  "5 Across": 7,
+  "Success Bell": 8,
+  "Startup Rocket": 9,
+  "Triangle Pin": 10,
+  "Work Anniversary": 11,
+  "Core Value Training": 12,
+  "Winter Retreat 2023": 13,
+  "Winter Retreat 2024": 14,
+  "Winter Retreat 2025": 15,
+};
+
+const DEFAULT_PIN_IMAGE = "/images/default-pin.png";
+
+// Memoized so page-level hover state changes don't re-render every pin
+const Pin = React.memo(function Pin({
   pin,
   setHoveredStory,
   pinType,
   imgLinks,
   scale,
   pinScale = 1,
-}) => {
+}) {
   const [dragging, setDragging] = useState(false);
 
   const handleDragStart = (e) => {
@@ -25,57 +48,10 @@ const Pin = ({
     );
   };
 
-  let imgSrc = "/images/default-pin.png";
-  switch (pinType) {
-    case "Be Good":
-      imgSrc = imgLinks[0].source;
-      break;
-    case "Be Excellent":
-      imgSrc = imgLinks[1].source;
-      break;
-    case "Be a Friend":
-      imgSrc = imgLinks[2].source;
-      break;
-    case "Be You":
-      imgSrc = imgLinks[3].source;
-      break;
-    case "Billi":
-      imgSrc = imgLinks[4].source;
-      break;
-    case "Oreo":
-      imgSrc = imgLinks[5].source;
-      break;
-    case "Balloon":
-      imgSrc = imgLinks[6].source;
-      break;
-    case "5 Across":
-      imgSrc = imgLinks[7].source;
-      break;
-    case "Success Bell":
-      imgSrc = imgLinks[8].source;
-      break;
-    case "Startup Rocket":
-      imgSrc = imgLinks[9].source;
-      break;
-    case "Triangle Pin":
-      imgSrc = imgLinks[10].source;
-      break;
-    case "Work Anniversary":
-      imgSrc = imgLinks[11].source;
-      break;
-    case "Core Value Training":
-      imgSrc = imgLinks[12].source;
-      break;
-    case "Winter Retreat 2023":
-      imgSrc = imgLinks[13].source;
-      break;
-    case "Winter Retreat 2024":
-      imgSrc = imgLinks[14].source;
-      break;
-    case "Winter Retreat 2025":
-      imgSrc = imgLinks[15].source;
-      break;
-  }
+  // Optional chaining keeps a missing row (or a failed pinImages fetch) from
+  // crashing the page — the pin just falls back to the default image.
+  const imgSrc =
+    imgLinks[PIN_IMAGE_INDEX[pinType]]?.source || DEFAULT_PIN_IMAGE;
 
   return (
     <motion.div
@@ -83,8 +59,8 @@ const Pin = ({
         position: "absolute",
         left: pin.x * scale,
         top: pin.y * scale,
-        width: PIN_SIZE * pinScale,
-        height: PIN_SIZE * pinScale,
+        width: PIN_SIZE * scale * pinScale,
+        height: PIN_SIZE * scale * pinScale,
         cursor: dragging ? "grabbing" : "grab",
         zIndex: dragging ? 1000 : 1,
       }}
@@ -99,11 +75,13 @@ const Pin = ({
       <img
         src={imgSrc}
         alt={pin.pinName}
-        style={{ width: 85 * scale * pinScale, height: "auto" }}
-        onError={(e) => (e.target.src = "/images/default-pin.png")}
+        loading="lazy"
+        decoding="async"
+        style={{ width: "100%", height: "auto" }}
+        onError={(e) => (e.target.src = DEFAULT_PIN_IMAGE)}
       />
     </motion.div>
   );
-};
+});
 
 export default Pin;

--- a/web/src/pages/team-achievements/index.js
+++ b/web/src/pages/team-achievements/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Container, Row, Col, Spinner } from "react-bootstrap";
 import { motion } from "framer-motion";
 import { useStaticQuery, graphql } from "gatsby";
@@ -33,13 +33,8 @@ const PinBoardPage = () => {
 
   // Optimal window size is 1440px
   // Idea is to scale entire boards based on window size
-  const [windowSize, setWindowSize] = useState({
-    width: typeof window !== "undefined" ? window.innerWidth : 1440,
-    scale: 1,
-  });
-
   const [scale, setScale] = useState(1);
-  const [pinScale, setPinScale] = useState(0.8);
+  const [pinScale] = useState(0.8);
 
   useEffect(() => {
     if (typeof window === "undefined") return; // No effect during server side rendering
@@ -59,46 +54,59 @@ const PinBoardPage = () => {
         newScale = Number(x.toFixed(2));
       }
 
-      setWindowSize({
-        width,
-        scale: newScale,
-      });
       setScale(newScale);
     };
     updateScale();
 
+    // Debounce so we don't re-render every board on every resize tick
+    let resizeTimer;
     const handleResize = () => {
-      updateScale();
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(updateScale, 150);
     };
 
     window.addEventListener("resize", handleResize);
 
     return () => {
+      clearTimeout(resizeTimer);
       window.removeEventListener("resize", handleResize);
     };
   }, []);
 
-  // Build array of team members, including startDate
-  const teamMembers = (allSanityTeamMember.nodes || []).map((n) => ({
-    name: n.name,
-    pinName: n.recipientName || "",
-    startDate: n.startDate,
-    pictureUrl: n.picture?.asset?.url || "",
-  }));
+  // Build array of team members, including startDate. Memoized so memoized
+  // CorkBoards don't see a new array identity on every page render.
+  const teamMembers = useMemo(
+    () =>
+      (allSanityTeamMember.nodes || []).map((n) => ({
+        name: n.name,
+        pinName: n.recipientName || "",
+        startDate: n.startDate,
+        pictureUrl: n.picture?.asset?.url || "",
+      })),
+    [allSanityTeamMember],
+  );
 
   // Create a Set of valid team member names
-  const memberNames = new Set(teamMembers.map((m) => m.pinName));
+  const memberNames = useMemo(
+    () => new Set(teamMembers.map((m) => m.pinName)),
+    [teamMembers],
+  );
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const resp = await fetch("/api/sheet");
-        if (!resp.ok) throw new Error("Network response failed");
-        const { pins } = await resp.json();
+        // Fetch pins and pin images in parallel — each hits the Google Sheets
+        // API, so running them serially doubles the loading time.
+        const [resp, links] = await Promise.all([
+          fetch("/api/sheet"),
+          fetch("/api/pinImages"),
+        ]);
+        if (!resp.ok || !links.ok) throw new Error("Network response failed");
 
-        const links = await fetch("/api/pinImages");
-        if (!links.ok) throw new Error("Network response failed");
-        const { imgLinks } = await links.json();
+        const [{ pins }, { imgLinks }] = await Promise.all([
+          resp.json(),
+          links.json(),
+        ]);
         setLinks(imgLinks);
 
         const grouped = pins.reduce((acc, p) => {
@@ -127,23 +135,26 @@ const PinBoardPage = () => {
     fetchData();
   }, []);
 
-// Only keep boards whose recipient matches a team member and isn't Nathan
-  const filteredBoards = boards.filter((board) => {
-  const recipient = board.recipient?.trim();
+  // Only keep boards whose recipient matches a team member and isn't Nathan,
+  // then split in half for the two columns.
+  const { halfOneBoards, halfTwoBoards } = useMemo(() => {
+    const filtered = boards.filter((board) => {
+      const recipient = board.recipient?.trim();
 
-  // Skip null, undefined, or Nathan Wilson
-  if (!recipient || recipient === "Nathan Wilson") {
-    return false;
-  }
+      // Skip null, undefined, or Nathan Wilson
+      if (!recipient || recipient === "Nathan Wilson") {
+        return false;
+      }
 
-  const exists = memberNames.has(recipient);
-  return exists;
-});
+      return memberNames.has(recipient);
+    });
 
-  // Split array in half for purposes of two columns
-  const half = filteredBoards.length / 2;
-  const halfTwoBoards = filteredBoards.splice(0, half);
-  const halfOneBoards = filteredBoards.splice(0, filteredBoards.length);
+    const half = Math.floor(filtered.length / 2);
+    return {
+      halfTwoBoards: filtered.slice(0, half),
+      halfOneBoards: filtered.slice(half),
+    };
+  }, [boards, memberNames]);
 
   return (
     <Layout>


### PR DESCRIPTION
## Summary
- Speed up `/team-achievements` by fetching pin logs and pin images in parallel, memoizing boards/pins so hover does not re-render every cork board, and lazy-loading pin/avatar images.
- Fix drag-and-drop placement: drop coordinates are converted from scaled CSS pixels back into unscaled board space so pins land under the cursor.
- Harden pin image lookup (no crash if a sheet row is missing) and remove noisy Sheets API console logs.

## Test plan
- [ ] Open `/team-achievements` and confirm boards still load and layout as before.
- [ ] Hover pins: story bar updates without the page hitching.
- [ ] Drag a pin: it should drop under the cursor at any viewport width.
